### PR TITLE
use stable version of library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "tijsverkoyen/css-to-inline-styles": "dev-master"
+        "tijsverkoyen/css-to-inline-styles": "~1.2"
     },
     "require-dev": {
         "symfony/framework-bundle": ">=2.1,<2.2-dev"


### PR DESCRIPTION
This PR fixes issues when root project uses stable `minimum-stability`. Constraint `~` indicates to use latest stable version of `tijverkoyen/css-to-inline-styles`
