### PR TITLE
convert encoding

### DIFF
--- a/Converter/ToInlineStyleEmailConverter.php
+++ b/Converter/ToInlineStyleEmailConverter.php
@@ -177,7 +177,7 @@ class ToInlineStyleEmailConverter {
             throw new MissingTemplatingEngineException("To use this function, a Container object must be passed to the constructor (@service_container service)");
         }
         /** @var EngineInterface $engine */
-        $engine = $this->container->get('templating'); 
+        $engine = $this->container->get('templating');
         $this->setHTML($engine->render($view, $parameters));
     }
 
@@ -205,9 +205,11 @@ class ToInlineStyleEmailConverter {
      */
     public function inlineCSS($html, $css, $outputXHTML = false)
     {
+        $html = mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8');
+
         $this->cssToInlineStyles->setHTML($html);
         $this->cssToInlineStyles->setCSS($css);
-        
+
         return $this->cssToInlineStyles->convert($outputXHTML);
     }
 }


### PR DESCRIPTION
When using the Twig "inlinecss" filter, I had an encoding problem ("é" replaced by "&Atilde;&copy;", "à" by "&Atilde;&nbsp;" ...)
This PR fix this problem, but I don't know if it BC break something. 
