### PR TITLE
Avoid setGlobals() notice in twig >= 1.2.3

### DIFF
--- a/Twig/InlineCssExtension.php
+++ b/Twig/InlineCssExtension.php
@@ -15,7 +15,7 @@ use RobertoTru\ToInlineStyleEmailBundle\Converter\ToInlineStyleEmailConverter;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Templating\TemplateNameParserInterface;
 
-class InlineCssExtension extends \Twig_Extension 
+class InlineCssExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
 {
     /**
      * @var ToInlineStyleEmailConverter


### PR DESCRIPTION
This fixes deprecation notices that occur as of twig 1.2.3 in least impactful way.

http://twig.sensiolabs.org/doc/deprecated.html
>As of Twig 1.23, the Twig_ExtensionInterface::getGlobals() method is deprecated. Implement Twig_Extension_GlobalsInterface to avoid deprecation notices.