### PR TITLE
Add License file & License name in readme.md

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,8 @@
+MIT License (MIT)
+Copyright (c) 2013-2016 Roberto Trunfio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Read the docs in the files for further details on the usage of the service.
 
 Contributing
 ============
-**ToInlineStyleEmailBundle** is an open source project. Contributions are encouraged. 
+**ToInlineStyleEmailBundle** is an open source project, under MIT license. Contributions are encouraged. 
 Feel free to contribute to improve this bundle.
 
 About the author of the bundle


### PR DESCRIPTION
Hi,

Your module had a license in composer.json
https://github.com/robertotru/ToInlineStyleEmailBundle/blob/master/composer.json
but it was not visible in the readme.
In order to avoid confusion, I added a license file and I mentioned the type of license chosen for your code in the readme

Regards,

Tomap
