### PR TITLE
Changed deprecated type hint Twig_NodeInterface to Twig_Node

### DIFF
--- a/Twig/InlineCssNode.php
+++ b/Twig/InlineCssNode.php
@@ -13,11 +13,11 @@ namespace RobertoTru\ToInlineStyleEmailBundle\Twig;
 
 use Twig_Compiler;
 
-class InlineCssNode extends \Twig_Node 
+class InlineCssNode extends \Twig_Node
 {
     private $debug;
-    
-    public function __construct(\Twig_NodeInterface $body, $css, $lineno = 0, $debug, $tag = 'inlinecss')
+
+    public function __construct(\Twig_Node $body, $css, $lineno = 0, $debug, $tag = 'inlinecss')
     {
         $this->debug = $debug;
         parent::__construct(array('body' => $body), array('css' => $css), $lineno, $tag);

--- a/Twig/InlineCssParser.php
+++ b/Twig/InlineCssParser.php
@@ -13,10 +13,10 @@ namespace RobertoTru\ToInlineStyleEmailBundle\Twig;
 
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Templating\TemplateNameParserInterface;
-use Twig_NodeInterface;
+use Twig_Node;
 use Twig_Token;
 
-class InlineCssParser extends \Twig_TokenParser 
+class InlineCssParser extends \Twig_TokenParser
 {
     /**
      * @var TemplateNameParserInterface
@@ -57,18 +57,18 @@ class InlineCssParser extends \Twig_TokenParser
      *
      * @param Twig_Token $token A Twig_Token instance
      *
-     * @return Twig_NodeInterface A Twig_NodeInterface instance
+     * @return Twig_Node A Twig_Node instance
      */
     public function parse(Twig_Token $token)
     {
         $lineNo = $token->getLine();
-        $stream = $this->parser->getStream(); 
+        $stream = $this->parser->getStream();
         $path = $stream->expect(Twig_Token::STRING_TYPE)->getValue();
         $stream->expect(Twig_Token::BLOCK_END_TYPE);
         $body = $this->parser->subparse(array($this, 'decideEnd'), true);
         $stream->expect(Twig_Token::BLOCK_END_TYPE);
 
-        return new InlineCssNode($body, $this->resolvePath($path), $lineNo, $this->debug); 
+        return new InlineCssNode($body, $this->resolvePath($path), $lineNo, $this->debug);
     }
 
     /**
@@ -80,7 +80,7 @@ class InlineCssParser extends \Twig_TokenParser
     {
         return 'inlinecss';
     }
-    
+
     public function decideEnd(Twig_Token $token)
     {
         return $token->test('endinlinecss');


### PR DESCRIPTION
Twig_NodeInterface was deprecated in 1.12 and was now removed in the just released Twig 2.0.

In order for this bundle to be also usable with Twig 2.0, the type hints have been updated to Twig_Node instead of Twig_NodeInterface.