### PR TITLE
Add Overridable Parameter Containing Path to Public Directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 phpunit.xml
 composer.lock
 /vendor

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $converter->setHTMLByView(
 );
 ```
 
-The preceding function must be used _in vece_ of function ```setHTML()```.
+The preceding function must be used _instead_ of ```setHTML()```.
 
 To use the ```generateStyledHTML``` method just use it like:
 
@@ -120,6 +120,10 @@ Dynamic variable is supported (Use absolute path with variable with asset or dir
 ```
 
 Read the docs in the files for further details on the usage of the service.
+
+Configuration
+=============
+The `css_to_inline_email_twig_extension.web_root` parameter contains the path to the root directory accessible to the web. This path is assumed to be a `web` directory just outside the kernel root directory as recommended in Symfony 2-3 (`%kernel.root_dir%/../web`). With Symfony 4, the recommended path moved to a `public` directory just outside the kernel root directory (`%kernel.root_dir%/../public`). Override the parameter with the correct path for your implementation.
 
 Contributing
 ============

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,6 +7,7 @@
     <parameters>
         <parameter key="css_to_inline_email_converter.class">RobertoTru\ToInlineStyleEmailBundle\Converter\ToInlineStyleEmailConverter</parameter>
         <parameter key="css_to_inline_email_twig_extension.class">RobertoTru\ToInlineStyleEmailBundle\Twig\InlineCssExtension</parameter>
+        <parameter key="css_to_inline_email_twig_extension.web_root">%kernel.root_dir%/../web</parameter>
     </parameters>
 
     <services>
@@ -16,7 +17,7 @@
         <service id="css_to_inline_email_twig_extension" class="%css_to_inline_email_twig_extension.class%">
             <argument type="service" id="css_to_inline_email_converter" />
             <argument type="service" id="file_locator" />
-            <argument>%kernel.root_dir%</argument>
+            <argument>%css_to_inline_email_twig_extension.web_root%</argument>
             <argument>%kernel.debug%</argument>
             <tag name="twig.extension" />
         </service>

--- a/Twig/InlineCssExtension.php
+++ b/Twig/InlineCssExtension.php
@@ -13,21 +13,30 @@ namespace RobertoTru\ToInlineStyleEmailBundle\Twig;
 
 use RobertoTru\ToInlineStyleEmailBundle\Converter\ToInlineStyleEmailConverter;
 use Symfony\Component\Config\FileLocatorInterface;
+use Twig\Extension\GlobalsInterface as TwigExtensionGlobalsInterface;
 
-class InlineCssExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
+/**
+ * Responsible to construct the instance responsible to inject the inline csss.
+ *
+ * @package RobertoTru\ToInlineStyleEmailBundle\Twig
+ */
+class InlineCssExtension extends \Twig_Extension implements TwigExtensionGlobalsInterface
 {
     /**
      * @var ToInlineStyleEmailConverter
      */
     private $inlineCss;
+
     /**
      * @var string
      */
     private $webRoot;
+
     /**
      * @var FileLocatorInterface
      */
     private $locator;
+
     /**
      * @var bool
      */
@@ -40,9 +49,9 @@ class InlineCssExtension extends \Twig_Extension implements \Twig_Extension_Glob
         $debug = false
     ) {
         $this->inlineCss = $inlineCss;
-        $this->locator = $locator;
-        $this->webRoot = $webRoot;
-        $this->debug = $debug;
+        $this->locator   = $locator;
+        $this->webRoot   = $webRoot;
+        $this->debug     = $debug;
     }
 
     /**

--- a/Twig/InlineCssExtension.php
+++ b/Twig/InlineCssExtension.php
@@ -13,7 +13,6 @@ namespace RobertoTru\ToInlineStyleEmailBundle\Twig;
 
 use RobertoTru\ToInlineStyleEmailBundle\Converter\ToInlineStyleEmailConverter;
 use Symfony\Component\Config\FileLocatorInterface;
-use Symfony\Component\Templating\TemplateNameParserInterface;
 
 class InlineCssExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
 {
@@ -24,7 +23,7 @@ class InlineCssExtension extends \Twig_Extension implements \Twig_Extension_Glob
     /**
      * @var string
      */
-    private $kernelRoot;
+    private $webRoot;
     /**
      * @var FileLocatorInterface
      */
@@ -37,12 +36,12 @@ class InlineCssExtension extends \Twig_Extension implements \Twig_Extension_Glob
     public function __construct(
         ToInlineStyleEmailConverter $inlineCss,
         FileLocatorInterface $locator,
-        $kernelRoot,
+        $webRoot,
         $debug = false
     ) {
         $this->inlineCss = $inlineCss;
         $this->locator = $locator;
-        $this->kernelRoot = $kernelRoot;
+        $this->webRoot = $webRoot;
         $this->debug = $debug;
     }
 
@@ -51,7 +50,7 @@ class InlineCssExtension extends \Twig_Extension implements \Twig_Extension_Glob
      */
     public function getTokenParsers()
     {
-        return array(new InlineCssParser($this->locator, $this->kernelRoot . '/../web', $this->debug));
+        return array(new InlineCssParser($this->locator, $this->webRoot, $this->debug));
     }
 
     /**

--- a/Twig/InlineCssParser.php
+++ b/Twig/InlineCssParser.php
@@ -12,7 +12,6 @@
 namespace RobertoTru\ToInlineStyleEmailBundle\Twig;
 
 use Symfony\Component\Config\FileLocatorInterface;
-use Symfony\Component\Templating\TemplateNameParserInterface;
 use Twig_Node;
 use Twig_Token;
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "gushphp/to-inline-style-email-bundle",
     "type": "symfony-bundle",
-    "description": "A Symfony2 bundle for using the CssToInlineStyles translator by tijsverkoyen",
+    "description": "A Symfony bundle for using the CssToInlineStyles translator by tijsverkoyen",
     "keywords": ["css", "inline", "style", "email", "symfony", "bundle"],
     "homepage": "http://github.com/gushphp/ToInlineStyleEmailBundle",
     "license": "MIT",
@@ -19,7 +19,8 @@
     },
     "require-dev": {
         "symfony/framework-bundle": "*",
-        "phpunit/phpunit": "^4.4"
+        "phpunit/phpunit": "^4.4",
+        "twig/twig": "*"
     },
     "autoload": {
         "psr-4": { "RobertoTru\\ToInlineStyleEmailBundle\\": "" }


### PR DESCRIPTION
We upgraded to Symfony 4 recently and this bundle was failing to locate our css files which had moved from `/web` to `/public` as recommended. This change adds a parameter so the assumed `/web` directory can be overridden to widen compatibility and flexibility.

- Adds `css_to_inline_email_twig_extension.web_root` parameter containing path to public directory
  (default remains as `web` just outside kernel root)
- Removes unused `use` statements
- Adds twig as dev dependency